### PR TITLE
leaving “reverseProxyBase” for good

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+RELAY_PORT=9999
+RELAY_DOMAIN=example.moblin.mys-lang.org
+RELAY_PATH=obs-remote-control-relay #delete this line if you want to host Relay on /

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,27 @@
+{$RELAY_DOMAIN} {
+    @has_relay_path expression {env.RELAY_PATH} != ""
+
+    handle @has_relay_path {
+		redir /{$RELAY_PATH} /{$RELAY_PATH}/ 301
+        route /{$RELAY_PATH}* {
+            uri strip_prefix /{$RELAY_PATH}
+            reverse_proxy http://localhost:{$RELAY_PORT} {
+                header_up X-Forwarded-For {remote_host}
+                header_up X-Real-IP {remote_host}
+                header_up Host {host}
+                header_up Upgrade {http.request.header.Upgrade}
+                header_up Connection {http.request.header.Connection}
+            }
+        }
+    }
+
+    handle {
+        reverse_proxy http://localhost:{$RELAY_PORT} {
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Real-IP {remote_host}
+            header_up Host {host}
+            header_up Upgrade {http.request.header.Upgrade}
+            header_up Connection {http.request.header.Connection}
+        }
+    }
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
-
 	"github.com/google/uuid"
 	"github.com/puzpuzpuz/xsync/v3"
 	"golang.org/x/time/rate"
@@ -91,7 +89,6 @@ func (b *Bridge) close(kicked bool) {
 }
 
 var address = flag.String("address", ":8080", "HTTP server address")
-var reverseProxyBase = flag.String("reverse_proxy_base", "", "Reverse proxy base (default: \"\")")
 
 var bridges = xsync.NewMapOf[string, *Bridge]()
 var startTime = time.Now()
@@ -372,11 +369,6 @@ func updateStats() {
 	}
 }
 
-func serveConfigJs(w http.ResponseWriter, _ *http.Request) {
-	configJs := fmt.Sprintf("const baseUrl = `${window.location.host}%v`;", *reverseProxyBase)
-	w.Header().Add("content-type", "text/javascript")
-	w.Write([]byte(configJs))
-}
 
 func main() {
 	flag.Parse()
@@ -394,9 +386,6 @@ func main() {
 	})
 	http.HandleFunc("/status/{bridgeId}", func(w http.ResponseWriter, r *http.Request) {
 		serveStatus(w, r)
-	})
-	http.HandleFunc("/config.js", func(w http.ResponseWriter, r *http.Request) {
-		serveConfigJs(w, r)
 	})
 	http.HandleFunc("/stats.json", func(w http.ResponseWriter, r *http.Request) {
 		serveStatsJson(w, r)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -234,7 +234,6 @@
       </div>
     </div>
 
-    <script src="config.js"></script>
     <script src="utils.js"></script>
     <script src="index.js"></script>
   </body>

--- a/frontend/server-status.html
+++ b/frontend/server-status.html
@@ -49,7 +49,6 @@
       </div>
     </div>
 
-    <script src="config.js"></script>
     <script src="utils.js"></script>
     <script src="server-status.js"></script>
   </body>

--- a/frontend/status.html
+++ b/frontend/status.html
@@ -55,7 +55,6 @@
       </div>
     </div>
 
-    <script src="config.js"></script>
     <script src="utils.js"></script>
     <script src="status.js"></script>
   </body>

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -1,3 +1,4 @@
+const baseUrl = `${window.location.host}${window.location.pathname}`.replace(/\/$/, '');
 const secure = `${window.location.protocol == "https:" ? "s" : ""}`;
 const wsScheme = `ws${secure}`;
 const httpScheme = `http${secure}`;


### PR DESCRIPTION
use ${window.location.pathname} for baseUrl
readme improvements
add caddy as webserver example

