### PR TITLE
Add Docker support and server status logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.gitignore
+.dockerignore
+README.md
+LICENSE
+screenshot.png
+backend/obs-remote-control-relay
+*.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,53 +1,50 @@
-name: Build and push Docker image
+name: Create and publish a Docker image
 
 on:
   push:
-    branches: [main]
-  release:
-    types: [published]
+    branches: ['main']
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
+  build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
+      attestations: write
+      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=
-            type=ref,event=branch
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+WORKDIR /build
+
+# Copy backend source and modules
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+COPY backend/*.go ./
+
+# Build static binary
+RUN CGO_ENABLED=0 go build -o relay .
+
+# Runtime stage
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+
+# Layout: binary in backend/, frontend as sibling (main.go serves from "../frontend")
+COPY --from=builder /build/relay backend/
+COPY frontend frontend
+
+WORKDIR /app/backend
+EXPOSE 8080
+
+ENTRYPOINT ["./relay"]
+CMD ["-address", ":8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,4 @@ COPY frontend frontend
 WORKDIR /app/backend
 EXPOSE 8080
 
-ENTRYPOINT ["./relay"]
-CMD ["-address", ":8080"]
+CMD ["./relay"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,39 @@ Server you can use (hosted in Tokyo): https://moblin.mys-lang.org/obs-remote-con
 
 A simple Go program serves a simple website and websocket endpoints.
 
+## Docker
+
+Pull image from repository:
+```bash
+docker pull ghcr.io/eerimoq/obs-remote-control-relay:latest
+
+docker run --rm -p 8080:8080 ghcr.io/eerimoq/obs-remote-control-relay
+```
+
+### Docker Compose
+
+```yaml
+services:
+  obs-relay:
+    image: ghcr.io/eerimoq/obs-remote-control-relay:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - LOG_LEVEL=INFO
+    restart: unless-stopped
+```
+
+
+## Systemd (no Docker)
+
 Run the Go program as a systemd service and use Nginx for TLS.
 
 ```
 cd backend && go build
 ```
 
-Set the log level with the `LOG_LEVEL` environment variable: `DEBUG`, `INFO` (default), `WARN`, or `ERROR`. Example: `LOG_LEVEL=DEBUG ./obs-remote-control-relay`
+Set the log level with the `LOG_LEVEL` environment variable: `DEBUG`, `INFO` (default), `WARN`, or `ERROR`.\
+Example: `LOG_LEVEL=DEBUG ./obs-remote-control-relay`
 
 ## Systemd service
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - LOG_LEVEL=INFO
+      - LOG_LEVEL=INFO # Default: 'INFO', Possible: INFO, WARN, ERROR, DEBUG
+      # - RELAY_ADDRESS=0.0.0.0:8080 # Default: ':8080', If you change the port here make sure to change the ports section above
+      # - RELAY_REVERSE_PROXY_BASE=/obs-remote-control-relay # Default: '/', Set this according to how you have your reverse proxy
     restart: unless-stopped
 ```
 
@@ -38,9 +40,6 @@ Run the Go program as a systemd service and use Nginx for TLS.
 ```
 cd backend && go build
 ```
-
-Set the log level with the `LOG_LEVEL` environment variable: `DEBUG`, `INFO` (default), `WARN`, or `ERROR`.\
-Example: `LOG_LEVEL=DEBUG ./obs-remote-control-relay`
 
 ## Systemd service
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Run the Go program as a systemd service and use Nginx for TLS.
 cd backend && go build
 ```
 
+Set the log level with the `LOG_LEVEL` environment variable: `DEBUG`, `INFO` (default), `WARN`, or `ERROR`. Example: `LOG_LEVEL=DEBUG ./obs-remote-control-relay`
+
 ## Systemd service
 
 /etc/systemd/system/obs-remote-control-relay.service

--- a/backend/main.go
+++ b/backend/main.go
@@ -434,9 +434,25 @@ func setLogLevel() {
 	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
 }
 
+func setVariablesFromEnvironment() {
+	var envAddress = os.Getenv("RELAY_ADDRESS")
+	var envReverseProxyBase = os.Getenv("RELAY_REVERSE_PROXY_BASE")
+
+	if envAddress != "" {
+		address = &envAddress
+	}
+
+	if envReverseProxyBase != "" {
+		reverseProxyBase = &envReverseProxyBase
+	}
+}
+
 func main() {
 	flag.Parse()
+
 	setLogLevel()
+	setVariablesFromEnvironment()
+
 	logger.Info("server starting", "address", *address, "reverse_proxy_base", *reverseProxyBase)
 	go updateStats()
 	static := http.FileServer(http.Dir("../frontend"))

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -19,60 +19,6 @@ import (
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
-
-// Log level constants (higher = more verbose)
-const (
-	levelError = iota
-	levelWarn
-	levelInfo
-	levelDebug
-)
-
-var levelNames = map[int]string{
-	levelError: "ERROR",
-	levelWarn:  "WARN",
-	levelInfo:  "INFO",
-	levelDebug: "DEBUG",
-}
-
-type appLogger struct {
-	level int
-	log   *log.Logger
-}
-
-func parseLogLevel(s string) int {
-	switch strings.ToUpper(strings.TrimSpace(s)) {
-	case "DEBUG":
-		return levelDebug
-	case "INFO", "":
-		return levelInfo
-	case "WARN", "WARNING":
-		return levelWarn
-	case "ERROR":
-		return levelError
-	default:
-		return levelInfo
-	}
-}
-
-func (l *appLogger) enabled(level int) bool { return level <= l.level }
-
-func (l *appLogger) logLine(level int, msg string, keysAndValues ...any) {
-	if !l.enabled(level) {
-		return
-	}
-	ts := time.Now().UTC().Format(time.RFC3339)
-	line := fmt.Sprintf("%s %-5s %s", ts, levelNames[level], msg)
-	for i := 0; i+1 < len(keysAndValues); i += 2 {
-		line += fmt.Sprintf(" %v=%v", keysAndValues[i], keysAndValues[i+1])
-	}
-	l.log.Output(3, line)
-}
-
-func (l *appLogger) Debug(msg string, keysAndValues ...any) { l.logLine(levelDebug, msg, keysAndValues...) }
-func (l *appLogger) Info(msg string, keysAndValues ...any)  { l.logLine(levelInfo, msg, keysAndValues...) }
-func (l *appLogger) Warn(msg string, keysAndValues ...any)  { l.logLine(levelWarn, msg, keysAndValues...) }
-func (l *appLogger) Error(msg string, keysAndValues ...any) { l.logLine(levelError, msg, keysAndValues...) }
 
 const controlMessageTypeConnect = "connect"
 const controlMessageTypeStartStatus = "startStatus"
@@ -106,11 +52,13 @@ func (c *Connection) close() {
 		remoteControllersConnected.Dec()
 		c.remoteControllerWebsocket.Close(websocket.StatusGoingAway, "")
 		c.remoteControllerWebsocket = nil
+		logger.Debug("closed remote controller websocket in connection")
 	}
 	if c.bridgeWebsocket != nil {
 		bridgeRemoteControllersConnected.Dec()
 		c.bridgeWebsocket.Close(websocket.StatusGoingAway, "")
 		c.bridgeWebsocket = nil
+		logger.Debug("closed bridge websocket in connection")
 	}
 	c.mutex.Unlock()
 }
@@ -131,9 +79,11 @@ func (b *Bridge) close(kicked bool) {
 				ControlMessage{
 					Type: controlMessageTypeKicked,
 				})
+			logger.Info("sent kicked control message to bridge before closing")
 		}
 		b.controlWebsocket.Close(websocket.StatusGoingAway, "")
 		b.controlWebsocket = nil
+		logger.Debug("closed bridge control websocket")
 	}
 	for _, connection := range b.connections {
 		connection.close()
@@ -158,6 +108,7 @@ var remoteControllerToBridgeBytes = xsync.NewCounter()
 var rateLimitExceeded = xsync.NewCounter()
 var bridgeToRemoteControllerBitrate atomic.Int64
 var remoteControllerToBridgeBitrate atomic.Int64
+var logger *slog.Logger
 
 var websocketSubprotocols = [1]string{"obswebsocket.json"}
 var websocketAcceptOptions = &websocket.AcceptOptions{
@@ -165,17 +116,15 @@ var websocketAcceptOptions = &websocket.AcceptOptions{
 	InsecureSkipVerify: true,
 }
 
-var logger *appLogger
-
 func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	bridgeId := r.PathValue("bridgeId")
+	context := r.Context()
 	bridgeControlWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
-		logger.Warn("bridge control websocket accept failed", "bridgeId", bridgeId, "error", err)
+		logger.Error("failed to accept bridge control websocket", "error", err.Error())
 		return
 	}
-	logger.Info("bridge control connected", "bridgeId", bridgeId)
+	bridgeId := r.PathValue("bridgeId")
+	logger.Info("bridge control websocket accepted", "bridgeId", bridgeId)
 	bridge := &Bridge{
 		mutex:            &sync.Mutex{},
 		controlWebsocket: bridgeControlWebsocket,
@@ -188,14 +137,14 @@ func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
 		bridgeToClose.close(true)
 	}
 	for {
-		messageType, message, err := bridgeControlWebsocket.Read(ctx)
+		messageType, message, err := bridgeControlWebsocket.Read(context)
 		if err != nil {
-			logger.Debug("bridge control read ended", "bridgeId", bridgeId, "error", err)
+			logger.Debug("bridge control read loop ended", "bridgeId", bridgeId, "error", err.Error())
 			break
 		}
 		bridge.mutex.Lock()
 		for statusWebsocket := range bridge.statusWebsockets {
-			statusWebsocket.Write(ctx, messageType, message)
+			statusWebsocket.Write(context, messageType, message)
 		}
 		bridge.mutex.Unlock()
 	}
@@ -204,8 +153,8 @@ func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
 		func(oldValue *Bridge, loaded bool) (*Bridge, bool) {
 			return oldValue, oldValue == bridge
 		})
+	logger.Info("closing bridge control", "bridgeId", bridgeId)
 	bridge.close(false)
-	logger.Info("bridge control disconnected", "bridgeId", bridgeId)
 }
 
 func handleRateLimitExceeded(bridgeControlWebsocket *websocket.Conn, connectionId string) {
@@ -222,18 +171,19 @@ func handleRateLimitExceeded(bridgeControlWebsocket *websocket.Conn, connectionI
 }
 
 func serveBridgeData(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	bridgeId := r.PathValue("bridgeId")
-	connectionId := r.PathValue("connectionId")
+	context := r.Context()
 	bridgeWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
-		logger.Warn("bridge data websocket accept failed", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
+		logger.Error("failed to accept bridge data websocket", "error", err.Error())
 		return
 	}
 	bridgeWebsocket.SetReadLimit(-1)
+	bridgeId := r.PathValue("bridgeId")
+	connectionId := r.PathValue("connectionId")
+	logger.Info("bridge data websocket accepted", "bridgeId", bridgeId, "connectionId", connectionId)
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
-		logger.Warn("bridge data rejected: bridge not found", "bridgeId", bridgeId, "connectionId", connectionId)
+		logger.Warn("bridge not found for data connection", "bridgeId", bridgeId, "connectionId", connectionId)
 		bridgeWebsocket.Close(websocket.StatusGoingAway, "")
 		return
 	}
@@ -241,7 +191,7 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 	connection := bridge.connections[connectionId]
 	if connection == nil {
 		bridge.mutex.Unlock()
-		logger.Warn("bridge data rejected: connection not found", "bridgeId", bridgeId, "connectionId", connectionId)
+		logger.Warn("connection not found for bridge data", "bridgeId", bridgeId, "connectionId", connectionId)
 		bridgeWebsocket.Close(websocket.StatusGoingAway, "")
 		return
 	}
@@ -252,11 +202,10 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 	connection.mutex.Unlock()
 	bridge.mutex.Unlock()
 	bridgeRemoteControllersConnected.Inc()
-	logger.Info("bridge data connected", "bridgeId", bridgeId, "connectionId", connectionId)
 	for {
-		messageType, message, err := bridgeWebsocket.Read(ctx)
+		messageType, message, err := bridgeWebsocket.Read(context)
 		if err != nil {
-			logger.Debug("bridge data read ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
+			logger.Debug("bridge data read loop ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err.Error())
 			break
 		}
 		length := len(message)
@@ -267,32 +216,33 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 		}
 		connection.mutex.Lock()
 		if connection.remoteControllerWebsocket != nil {
-			connection.remoteControllerWebsocket.Write(ctx, messageType, message)
+			connection.remoteControllerWebsocket.Write(context, messageType, message)
 		}
 		connection.mutex.Unlock()
 	}
 	bridge.mutex.Lock()
 	delete(bridge.connections, connectionId)
 	bridge.mutex.Unlock()
+	logger.Info("bridge data connection closed", "bridgeId", bridgeId, "connectionId", connectionId)
 	connection.close()
-	logger.Info("bridge data disconnected", "bridgeId", bridgeId, "connectionId", connectionId)
 }
 
 func serveRemoteController(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	context := r.Context()
 	bridgeId := r.PathValue("bridgeId")
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
-		logger.Warn("remote controller rejected: bridge not found", "bridgeId", bridgeId)
+		logger.Warn("bridge not found for remote controller", "bridgeId", bridgeId)
 		return
 	}
 	remoteControllerWebsocket, err := websocket.Accept(w, r, websocketAcceptOptions)
 	if err != nil {
-		logger.Warn("remote controller websocket accept failed", "bridgeId", bridgeId, "error", err)
+		logger.Error("failed to accept remote controller websocket", "bridgeId", bridgeId, "error", err.Error())
 		return
 	}
 	remoteControllerWebsocket.SetReadLimit(-1)
 	connectionId := uuid.New().String()
+	logger.Info("remote controller connected", "bridgeId", bridgeId, "connectionId", connectionId)
 	// Average 0.5 Mbps, burst 10 Mbps.
 	rateLimiter := rate.NewLimiter(rate.Every(time.Microsecond)/2, 10000000)
 	connection := &Connection{
@@ -301,11 +251,10 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 		rateLimiter:               rateLimiter,
 	}
 	remoteControllersConnected.Inc()
-	logger.Info("remote controller connected", "bridgeId", bridgeId, "connectionId", connectionId)
 	bridge.mutex.Lock()
 	bridge.connections[connectionId] = connection
 	bridgeControlWebsocket := bridge.controlWebsocket
-	wsjson.Write(ctx, bridgeControlWebsocket, ControlMessage{
+	wsjson.Write(context, bridgeControlWebsocket, ControlMessage{
 		Type: controlMessageTypeConnect,
 		Data: ControlConnectData{
 			ConnectionId: connectionId,
@@ -313,9 +262,9 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 	})
 	bridge.mutex.Unlock()
 	for {
-		messageType, message, err := remoteControllerWebsocket.Read(ctx)
+		messageType, message, err := remoteControllerWebsocket.Read(context)
 		if err != nil {
-			logger.Debug("remote controller read ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
+			logger.Debug("remote controller read loop ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err.Error())
 			break
 		}
 		length := len(message)
@@ -327,58 +276,61 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 		connection.mutex.Lock()
 		if connection.bridgeWebsocket == nil {
 			connection.mutex.Unlock()
+			logger.Debug("remote controller bridge websocket nil, ending loop", "bridgeId", bridgeId, "connectionId", connectionId)
 			break
 		}
-		connection.bridgeWebsocket.Write(ctx, messageType, message)
+		connection.bridgeWebsocket.Write(context, messageType, message)
 		connection.mutex.Unlock()
 	}
 	bridge.mutex.Lock()
 	delete(bridge.connections, connectionId)
 	bridge.mutex.Unlock()
-	connection.close()
 	logger.Info("remote controller disconnected", "bridgeId", bridgeId, "connectionId", connectionId)
+	connection.close()
 }
 
 func serveStatus(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	context := r.Context()
 	bridgeId := r.PathValue("bridgeId")
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
-		logger.Warn("status websocket rejected: bridge not found", "bridgeId", bridgeId)
+		logger.Warn("bridge not found for status", "bridgeId", bridgeId)
 		return
 	}
 	statusWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
-		logger.Warn("status websocket accept failed", "bridgeId", bridgeId, "error", err)
+		logger.Error("failed to accept status websocket", "bridgeId", bridgeId, "error", err.Error())
 		return
 	}
 	statusWebsocket.SetReadLimit(-1)
+	logger.Info("status websocket accepted", "bridgeId", bridgeId)
 	bridge.mutex.Lock()
 	if len(bridge.statusWebsockets) == 0 {
 		if bridge.controlWebsocket == nil {
 			bridge.mutex.Unlock()
 			return
 		}
-		wsjson.Write(ctx, bridge.controlWebsocket, ControlMessage{
+		wsjson.Write(context, bridge.controlWebsocket, ControlMessage{
 			Type: controlMessageTypeStartStatus,
 		})
+		logger.Debug("sent startStatus to bridge control", "bridgeId", bridgeId)
 	}
 	bridge.statusWebsockets[statusWebsocket] = true
 	bridge.mutex.Unlock()
-	logger.Debug("status websocket connected", "bridgeId", bridgeId)
-	_, _, _ = statusWebsocket.Read(ctx)
+	_, _, _ = statusWebsocket.Read(context)
 	bridge.mutex.Lock()
 	delete(bridge.statusWebsockets, statusWebsocket)
 	if len(bridge.statusWebsockets) == 0 {
 		if bridge.controlWebsocket != nil {
-			wsjson.Write(ctx, bridge.controlWebsocket, ControlMessage{
+			wsjson.Write(context, bridge.controlWebsocket, ControlMessage{
 				Type: controlMessageTypeStopStatus,
 			})
+			logger.Debug("sent stopStatus to bridge control", "bridgeId", bridgeId)
 		}
 	}
 	bridge.mutex.Unlock()
+	logger.Info("status websocket closed", "bridgeId", bridgeId)
 	statusWebsocket.Close(websocket.StatusAbnormalClosure, "")
-	logger.Debug("status websocket disconnected", "bridgeId", bridgeId)
 }
 
 type StatsGeneral struct {
@@ -412,8 +364,8 @@ type Stats struct {
 	Traffic           StatsTraffic           `json:"traffic"`
 }
 
-func serveStatsJson(w http.ResponseWriter, r *http.Request) {
-	logger.Debug("stats requested", "remoteAddr", r.RemoteAddr)
+func serveStatsJson(w http.ResponseWriter, _ *http.Request) {
+	logger.Debug("stats.json requested")
 	stats := Stats{
 		General: StatsGeneral{
 			StartTime:         startTime.Unix(),
@@ -439,7 +391,6 @@ func serveStatsJson(w http.ResponseWriter, r *http.Request) {
 	}
 	statsJson, err := json.Marshal(stats)
 	if err != nil {
-		logger.Error("failed to marshal stats", "error", err)
 		return
 	}
 	w.Header().Add("content-type", "application/json")
@@ -447,6 +398,7 @@ func serveStatsJson(w http.ResponseWriter, r *http.Request) {
 }
 
 func updateStats() {
+	logger.Debug("stats bitrate updater started")
 	var prevBridgeToRemoteControllerBytes int64
 	var prevRemoteControllerToBridgeBytes int64
 	for {
@@ -461,22 +413,31 @@ func updateStats() {
 }
 
 func serveConfigJs(w http.ResponseWriter, _ *http.Request) {
+	logger.Debug("config.mjs requested")
 	configJs := fmt.Sprintf("export const baseUrl = `${window.location.host}%v`;", *reverseProxyBase)
 	w.Header().Add("content-type", "text/javascript")
 	w.Write([]byte(configJs))
 }
 
+func setLogLevel() {
+	level := slog.LevelInfo
+	switch strings.ToUpper(strings.TrimSpace(os.Getenv("LOG_LEVEL"))) {
+	case "DEBUG":
+		level = slog.LevelDebug
+	case "INFO", "":
+		level = slog.LevelInfo
+	case "WARN", "WARNING":
+		level = slog.LevelWarn
+	case "ERROR":
+		level = slog.LevelError
+	}
+	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+}
+
 func main() {
 	flag.Parse()
-	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
-	logger = &appLogger{
-		level: logLevel,
-		log:   log.New(os.Stdout, "", 0),
-	}
-	logger.Info("starting OBS remote control relay",
-		"address", *address,
-		"reverseProxyBase", *reverseProxyBase,
-		"logLevel", levelNames[logLevel])
+	setLogLevel()
+	logger.Info("server starting", "address", *address, "reverse_proxy_base", *reverseProxyBase)
 	go updateStats()
 	static := http.FileServer(http.Dir("../frontend"))
 	http.Handle("/", static)
@@ -498,10 +459,9 @@ func main() {
 	http.HandleFunc("/stats.json", func(w http.ResponseWriter, r *http.Request) {
 		serveStatsJson(w, r)
 	})
-	logger.Info("HTTP server listening", "address", *address)
+	logger.Info("listening for HTTP requests", "address", *address)
 	err := http.ListenAndServe(*address, nil)
 	if err != nil {
-		logger.Error("HTTP server failed", "error", err)
-		log.Fatal("ListenAndServe: ", err)
+		logger.Error("ListenAndServe failed", "error", err.Error())
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +19,60 @@ import (
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
+
+// Log level constants (higher = more verbose)
+const (
+	levelError = iota
+	levelWarn
+	levelInfo
+	levelDebug
+)
+
+var levelNames = map[int]string{
+	levelError: "ERROR",
+	levelWarn:  "WARN",
+	levelInfo:  "INFO",
+	levelDebug: "DEBUG",
+}
+
+type appLogger struct {
+	level int
+	log   *log.Logger
+}
+
+func parseLogLevel(s string) int {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "DEBUG":
+		return levelDebug
+	case "INFO", "":
+		return levelInfo
+	case "WARN", "WARNING":
+		return levelWarn
+	case "ERROR":
+		return levelError
+	default:
+		return levelInfo
+	}
+}
+
+func (l *appLogger) enabled(level int) bool { return level <= l.level }
+
+func (l *appLogger) logLine(level int, msg string, keysAndValues ...any) {
+	if !l.enabled(level) {
+		return
+	}
+	ts := time.Now().UTC().Format(time.RFC3339)
+	line := fmt.Sprintf("%s %-5s %s", ts, levelNames[level], msg)
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		line += fmt.Sprintf(" %v=%v", keysAndValues[i], keysAndValues[i+1])
+	}
+	l.log.Output(3, line)
+}
+
+func (l *appLogger) Debug(msg string, keysAndValues ...any) { l.logLine(levelDebug, msg, keysAndValues...) }
+func (l *appLogger) Info(msg string, keysAndValues ...any)  { l.logLine(levelInfo, msg, keysAndValues...) }
+func (l *appLogger) Warn(msg string, keysAndValues ...any)  { l.logLine(levelWarn, msg, keysAndValues...) }
+func (l *appLogger) Error(msg string, keysAndValues ...any) { l.logLine(levelError, msg, keysAndValues...) }
 
 const controlMessageTypeConnect = "connect"
 const controlMessageTypeStartStatus = "startStatus"
@@ -109,13 +165,17 @@ var websocketAcceptOptions = &websocket.AcceptOptions{
 	InsecureSkipVerify: true,
 }
 
+var logger *appLogger
+
 func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
-	context := r.Context()
+	ctx := r.Context()
+	bridgeId := r.PathValue("bridgeId")
 	bridgeControlWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
+		logger.Warn("bridge control websocket accept failed", "bridgeId", bridgeId, "error", err)
 		return
 	}
-	bridgeId := r.PathValue("bridgeId")
+	logger.Info("bridge control connected", "bridgeId", bridgeId)
 	bridge := &Bridge{
 		mutex:            &sync.Mutex{},
 		controlWebsocket: bridgeControlWebsocket,
@@ -124,16 +184,18 @@ func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
 	}
 	bridgeToClose, loaded := bridges.LoadAndStore(bridgeId, bridge)
 	if loaded {
+		logger.Info("replacing existing bridge", "bridgeId", bridgeId)
 		bridgeToClose.close(true)
 	}
 	for {
-		messageType, message, err := bridgeControlWebsocket.Read(context)
+		messageType, message, err := bridgeControlWebsocket.Read(ctx)
 		if err != nil {
+			logger.Debug("bridge control read ended", "bridgeId", bridgeId, "error", err)
 			break
 		}
 		bridge.mutex.Lock()
 		for statusWebsocket := range bridge.statusWebsockets {
-			statusWebsocket.Write(context, messageType, message)
+			statusWebsocket.Write(ctx, messageType, message)
 		}
 		bridge.mutex.Unlock()
 	}
@@ -143,10 +205,12 @@ func serveBridgeControl(w http.ResponseWriter, r *http.Request) {
 			return oldValue, oldValue == bridge
 		})
 	bridge.close(false)
+	logger.Info("bridge control disconnected", "bridgeId", bridgeId)
 }
 
 func handleRateLimitExceeded(bridgeControlWebsocket *websocket.Conn, connectionId string) {
 	rateLimitExceeded.Inc()
+	logger.Warn("rate limit exceeded", "connectionId", connectionId)
 	wsjson.Write(context.Background(),
 		bridgeControlWebsocket,
 		ControlMessage{
@@ -158,16 +222,18 @@ func handleRateLimitExceeded(bridgeControlWebsocket *websocket.Conn, connectionI
 }
 
 func serveBridgeData(w http.ResponseWriter, r *http.Request) {
-	context := r.Context()
+	ctx := r.Context()
+	bridgeId := r.PathValue("bridgeId")
+	connectionId := r.PathValue("connectionId")
 	bridgeWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
+		logger.Warn("bridge data websocket accept failed", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
 		return
 	}
 	bridgeWebsocket.SetReadLimit(-1)
-	bridgeId := r.PathValue("bridgeId")
-	connectionId := r.PathValue("connectionId")
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
+		logger.Warn("bridge data rejected: bridge not found", "bridgeId", bridgeId, "connectionId", connectionId)
 		bridgeWebsocket.Close(websocket.StatusGoingAway, "")
 		return
 	}
@@ -175,6 +241,7 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 	connection := bridge.connections[connectionId]
 	if connection == nil {
 		bridge.mutex.Unlock()
+		logger.Warn("bridge data rejected: connection not found", "bridgeId", bridgeId, "connectionId", connectionId)
 		bridgeWebsocket.Close(websocket.StatusGoingAway, "")
 		return
 	}
@@ -185,9 +252,11 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 	connection.mutex.Unlock()
 	bridge.mutex.Unlock()
 	bridgeRemoteControllersConnected.Inc()
+	logger.Info("bridge data connected", "bridgeId", bridgeId, "connectionId", connectionId)
 	for {
-		messageType, message, err := bridgeWebsocket.Read(context)
+		messageType, message, err := bridgeWebsocket.Read(ctx)
 		if err != nil {
+			logger.Debug("bridge data read ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
 			break
 		}
 		length := len(message)
@@ -198,7 +267,7 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 		}
 		connection.mutex.Lock()
 		if connection.remoteControllerWebsocket != nil {
-			connection.remoteControllerWebsocket.Write(context, messageType, message)
+			connection.remoteControllerWebsocket.Write(ctx, messageType, message)
 		}
 		connection.mutex.Unlock()
 	}
@@ -206,17 +275,20 @@ func serveBridgeData(w http.ResponseWriter, r *http.Request) {
 	delete(bridge.connections, connectionId)
 	bridge.mutex.Unlock()
 	connection.close()
+	logger.Info("bridge data disconnected", "bridgeId", bridgeId, "connectionId", connectionId)
 }
 
 func serveRemoteController(w http.ResponseWriter, r *http.Request) {
-	context := r.Context()
+	ctx := r.Context()
 	bridgeId := r.PathValue("bridgeId")
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
+		logger.Warn("remote controller rejected: bridge not found", "bridgeId", bridgeId)
 		return
 	}
 	remoteControllerWebsocket, err := websocket.Accept(w, r, websocketAcceptOptions)
 	if err != nil {
+		logger.Warn("remote controller websocket accept failed", "bridgeId", bridgeId, "error", err)
 		return
 	}
 	remoteControllerWebsocket.SetReadLimit(-1)
@@ -229,10 +301,11 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 		rateLimiter:               rateLimiter,
 	}
 	remoteControllersConnected.Inc()
+	logger.Info("remote controller connected", "bridgeId", bridgeId, "connectionId", connectionId)
 	bridge.mutex.Lock()
 	bridge.connections[connectionId] = connection
 	bridgeControlWebsocket := bridge.controlWebsocket
-	wsjson.Write(context, bridgeControlWebsocket, ControlMessage{
+	wsjson.Write(ctx, bridgeControlWebsocket, ControlMessage{
 		Type: controlMessageTypeConnect,
 		Data: ControlConnectData{
 			ConnectionId: connectionId,
@@ -240,8 +313,9 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 	})
 	bridge.mutex.Unlock()
 	for {
-		messageType, message, err := remoteControllerWebsocket.Read(context)
+		messageType, message, err := remoteControllerWebsocket.Read(ctx)
 		if err != nil {
+			logger.Debug("remote controller read ended", "bridgeId", bridgeId, "connectionId", connectionId, "error", err)
 			break
 		}
 		length := len(message)
@@ -255,50 +329,56 @@ func serveRemoteController(w http.ResponseWriter, r *http.Request) {
 			connection.mutex.Unlock()
 			break
 		}
-		connection.bridgeWebsocket.Write(context, messageType, message)
+		connection.bridgeWebsocket.Write(ctx, messageType, message)
 		connection.mutex.Unlock()
 	}
 	bridge.mutex.Lock()
 	delete(bridge.connections, connectionId)
 	bridge.mutex.Unlock()
 	connection.close()
+	logger.Info("remote controller disconnected", "bridgeId", bridgeId, "connectionId", connectionId)
 }
 
 func serveStatus(w http.ResponseWriter, r *http.Request) {
-	context := r.Context()
+	ctx := r.Context()
 	bridgeId := r.PathValue("bridgeId")
 	bridge, ok := bridges.Load(bridgeId)
 	if !ok {
+		logger.Warn("status websocket rejected: bridge not found", "bridgeId", bridgeId)
 		return
 	}
 	statusWebsocket, err := websocket.Accept(w, r, nil)
 	if err != nil {
+		logger.Warn("status websocket accept failed", "bridgeId", bridgeId, "error", err)
 		return
 	}
 	statusWebsocket.SetReadLimit(-1)
 	bridge.mutex.Lock()
 	if len(bridge.statusWebsockets) == 0 {
 		if bridge.controlWebsocket == nil {
+			bridge.mutex.Unlock()
 			return
 		}
-		wsjson.Write(context, bridge.controlWebsocket, ControlMessage{
+		wsjson.Write(ctx, bridge.controlWebsocket, ControlMessage{
 			Type: controlMessageTypeStartStatus,
 		})
 	}
 	bridge.statusWebsockets[statusWebsocket] = true
 	bridge.mutex.Unlock()
-	_, _, _ = statusWebsocket.Read(context)
+	logger.Debug("status websocket connected", "bridgeId", bridgeId)
+	_, _, _ = statusWebsocket.Read(ctx)
 	bridge.mutex.Lock()
 	delete(bridge.statusWebsockets, statusWebsocket)
 	if len(bridge.statusWebsockets) == 0 {
 		if bridge.controlWebsocket != nil {
-			wsjson.Write(context, bridge.controlWebsocket, ControlMessage{
+			wsjson.Write(ctx, bridge.controlWebsocket, ControlMessage{
 				Type: controlMessageTypeStopStatus,
 			})
 		}
 	}
 	bridge.mutex.Unlock()
 	statusWebsocket.Close(websocket.StatusAbnormalClosure, "")
+	logger.Debug("status websocket disconnected", "bridgeId", bridgeId)
 }
 
 type StatsGeneral struct {
@@ -332,7 +412,8 @@ type Stats struct {
 	Traffic           StatsTraffic           `json:"traffic"`
 }
 
-func serveStatsJson(w http.ResponseWriter, _ *http.Request) {
+func serveStatsJson(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("stats requested", "remoteAddr", r.RemoteAddr)
 	stats := Stats{
 		General: StatsGeneral{
 			StartTime:         startTime.Unix(),
@@ -358,6 +439,7 @@ func serveStatsJson(w http.ResponseWriter, _ *http.Request) {
 	}
 	statsJson, err := json.Marshal(stats)
 	if err != nil {
+		logger.Error("failed to marshal stats", "error", err)
 		return
 	}
 	w.Header().Add("content-type", "application/json")
@@ -386,6 +468,15 @@ func serveConfigJs(w http.ResponseWriter, _ *http.Request) {
 
 func main() {
 	flag.Parse()
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger = &appLogger{
+		level: logLevel,
+		log:   log.New(os.Stdout, "", 0),
+	}
+	logger.Info("starting OBS remote control relay",
+		"address", *address,
+		"reverseProxyBase", *reverseProxyBase,
+		"logLevel", levelNames[logLevel])
 	go updateStats()
 	static := http.FileServer(http.Dir("../frontend"))
 	http.Handle("/", static)
@@ -407,8 +498,10 @@ func main() {
 	http.HandleFunc("/stats.json", func(w http.ResponseWriter, r *http.Request) {
 		serveStatsJson(w, r)
 	})
+	logger.Info("HTTP server listening", "address", *address)
 	err := http.ListenAndServe(*address, nil)
 	if err != nil {
+		logger.Error("HTTP server failed", "error", err)
 		log.Fatal("ListenAndServe: ", err)
 	}
 }

--- a/frontend/js/index.mjs
+++ b/frontend/js/index.mjs
@@ -6,6 +6,7 @@ import {
   bitrateToString,
   httpScheme,
   addOnClick,
+  randomUUID,
 } from "./utils.mjs";
 import { baseUrl } from "./config.mjs";
 
@@ -362,7 +363,7 @@ function saveSettings() {
 }
 
 function resetSettings() {
-  bridgeId = crypto.randomUUID();
+  bridgeId = randomUUID();
   localStorage.setItem("bridgeId", bridgeId);
   obsPort = defaultObsPort;
   localStorage.setItem("obsPort", obsPort);
@@ -457,7 +458,7 @@ function loadbridgeId(urlParams) {
     bridgeId = localStorage.getItem("bridgeId");
   }
   if (bridgeId == undefined) {
-    bridgeId = crypto.randomUUID();
+    bridgeId = randomUUID();
   }
   localStorage.setItem("bridgeId", bridgeId);
 }

--- a/frontend/js/status.mjs
+++ b/frontend/js/status.mjs
@@ -4,6 +4,7 @@ import {
   getTableBody,
   appendToRow,
   bitrateToString,
+  randomUUID,
 } from "./utils.mjs";
 import { baseUrl } from "./config.mjs";
 
@@ -77,7 +78,7 @@ function updateConnections(connections) {
 function loadbridgeId(urlParams) {
   bridgeId = urlParams.get("bridgeId");
   if (bridgeId == undefined) {
-    bridgeId = crypto.randomUUID();
+    bridgeId = randomUUID();
   }
 }
 

--- a/frontend/js/utils.mjs
+++ b/frontend/js/utils.mjs
@@ -2,6 +2,17 @@ const secure = `${window.location.protocol == "https:" ? "s" : ""}`;
 export const wsScheme = `ws${secure}`;
 export const httpScheme = `http${secure}`;
 
+export function randomUUID() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 function numberSuffix(value) {
   return value == 1 ? "" : "s";
 }


### PR DESCRIPTION
Hi, I'm creating this PR because I wanted to run this locally in docker, and since I might not be the only one, I tried to make it as simple as possible. Most of the changes were made with AI (monstly the logging in the go files, because I don't know go and it's faster).

- Added a `dockerfile` that compiles and runs the relay on port 8080 by default.
- Added logs to the go file to better track what is happening.
- Added randomUUID() helper function with a fallback for when crypto is no available.
- Added a github action that builds and publishes the image to github packages.

Docker will run the relay as such:
```bash
./relay -address 0.0.0.0:8080
```